### PR TITLE
Added filter option to allow filtering of submodules using config.

### DIFF
--- a/tasks/submodule.js
+++ b/tasks/submodule.js
@@ -24,7 +24,7 @@ module.exports = function (grunt) {
     });
     var data = grunt.config(this.name) || {};
     var done = this.async();
-    var filter = options.filter ? minimatch.filter(options.filter) : function () { return true; });
+    var filter = options.filter ? minimatch.filter(options.filter) : function () { return true; };
 
     function getOptions(submodule) {
       var sources = [];


### PR DESCRIPTION
I really needed to be able to filter out some submodules which don't support Grunt tasks. This gives you an option 'filter' which you can specify in the task configuration. It specifies a standard minimatch filter string.
